### PR TITLE
#32 Fixing MetadataProvidersBase requiring 'any' …

### DIFF
--- a/endpoint-spec/package.json
+++ b/endpoint-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/endpoint-spec",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/endpoint-spec/src/common.ts
+++ b/endpoint-spec/src/common.ts
@@ -19,8 +19,8 @@ export type MetadataProvidersBase<
     TStringEncoder,
     TOutputContents,
     TInputContents,
-    unknown,
-    unknown,
+    any,
+    any,
     unknown
   >
 >;


### PR DESCRIPTION
…instead of 'unknown', as 'unknown' breaks some of the legit usages in client libraries.