### PR TITLE
#32 Not enough generic parameters were set as 'an…

### DIFF
--- a/endpoint-spec/package.json
+++ b/endpoint-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/endpoint-spec",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/endpoint-spec/src/common.ts
+++ b/endpoint-spec/src/common.ts
@@ -9,12 +9,12 @@ export type MetadataProvidersBase<
   TInputContents extends data.TInputContentsBase,
 > = Record<
   string,
-  // We must use 'any' as 2nd parameter, otherwise we won't be able to use AppEndpointBuilderProvider with specific TMetadataProviders type as parameter to functions.
+  // We must use 'any' as some parameters, otherwise we won't be able to use AppEndpointBuilderProvider with specific TMetadataProviders type as parameter to functions.
   md.MetadataProvider<
     md.HKTArg,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any,
-    unknown,
+    any,
     TStringDecoder,
     TStringEncoder,
     TOutputContents,

--- a/endpoint-spec/src/stage3.ts
+++ b/endpoint-spec/src/stage3.ts
@@ -86,6 +86,7 @@ export class AppEndpointBuilder<
         getMetadata: (urlPrefix) => ({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           metadata: data.transformEntries(metadata, (md) =>
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             md(urlPrefix),
           ) as any, // eslint-disable-line @typescript-eslint/no-explicit-any
           stateInfo: Object.fromEntries(


### PR DESCRIPTION
…y' previously.